### PR TITLE
Fix bug that caused WebPack Dev Server to start during one-off scripts

### DIFF
--- a/server/boot/frontend.js
+++ b/server/boot/frontend.js
@@ -7,32 +7,34 @@ module.exports = function(server) {
 
   var isDev = process.env.NODE_ENV === 'dev';
 
-  if (isDev) {
-    var httpProxy = require('http-proxy');
-    var proxy = httpProxy.createProxyServer({
-      changeOrigin: true,
-      ws: true
-    });
-
-    var bundle = require('../frontend/bundle.js');
-    bundle();
-    server.all('/build/*', function (req, res) {
-      proxy.web(req, res, {
-        target: 'http://127.0.0.1:3001'
+  server.on('started', function() {
+    if (isDev) {
+      var httpProxy = require('http-proxy');
+      var proxy = httpProxy.createProxyServer({
+        changeOrigin: true,
+        ws: true
       });
-    });
-    server.all('/socket.io*', function (req, res) {
-      proxy.web(req, res, {
-        target: 'http://127.0.0.1:3001'
+
+      var bundle = require('../frontend/bundle.js');
+      bundle();
+      server.all('/build/*', function (req, res) {
+        proxy.web(req, res, {
+          target: 'http://127.0.0.1:3001'
+        });
       });
-    });
+      server.all('/socket.io*', function (req, res) {
+        proxy.web(req, res, {
+          target: 'http://127.0.0.1:3001'
+        });
+      });
 
-    proxy.on('error', function(e) {
-      // Just catch it
-    });
+      proxy.on('error', function(e) {
+        // Just catch it
+      });
 
-    server.on('upgrade', function (req, socket, head) {
-      proxy.ws(req, socket, head);
-    });
-  }
+      server.on('upgrade', function (req, socket, head) {
+        proxy.ws(req, socket, head);
+      });
+    }
+  });
 };


### PR DESCRIPTION
This caused an EADDRINUSE error if the dev server was also running.

This was caused by frontend.js detecting if the server was running by checking if NODE_ENV was "dev". This broke in Vagrant setup were NODE_ENV==dev all the time. The naive implementation was replaced with a more robust setup that listens for the server's "started" event.
