### PR TITLE
Npm-asennuksille vagrantfilessä early exit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,6 +68,7 @@ npm install -g strongloop || exit 1
 
 npm install || exit 1
 
+sudo -u postgres npm run dev-teardown || exit 1
 sudo -u postgres npm run dev-setup || exit 1
 
 exit 0


### PR DESCRIPTION
Nyt jos yksikin npm-asennuksista epäonnistuu, keskeytetään asentaminen eikä edes yritetä loppuja.

Lisäksi tietokannan teardown ennen tietokannan&taulujen luontia samaan skriptiin, jotta skriptien uudelleenajaminen johtaisi aina samaan lopputulokseen.
