### PR TITLE
Järkevöittää käyttäjän ja laskentakohteiden välistä linkitystä

### DIFF
--- a/common/fixtures/test-only/Costcenter.json
+++ b/common/fixtures/test-only/Costcenter.json
@@ -2,8 +2,7 @@
   {
     "code": "00000",
     "name": "Roihun johtoryhmä",
-    "controller": 3,
-    "provider": 4,
-    "master": 2
+    "approverUserId": 2,
+    "controllerUserId": 3
   }
 ]

--- a/common/fixtures/test-only/Purchaseuser.json
+++ b/common/fixtures/test-only/Purchaseuser.json
@@ -30,20 +30,20 @@
     "userSection": "Palvelut"
   },
   {
-  	"id": 4,
-  	"username": "procurementMaster",
-  	"password": "$2a$10$1rllCFIqdWhaGQM4sEnQEuUa0XSTyRjuzhXo39VEdyUDOVuc93cGC",
-  	"name": "Pekka Päällikkö",
+    "id": 4,
+    "username": "procurementMaster",
+    "password": "$2a$10$1rllCFIqdWhaGQM4sEnQEuUa0XSTyRjuzhXo39VEdyUDOVuc93cGC",
+    "name": "Pekka Päällikkö",
     "phone": "040 3456789",
     "email": "pekka.paallikko@roihu2016.fi",
     "enlistment": "Päällikkö",
     "userSection": "Palvelut"
   },
   {
-  	"id": 5,
-  	"username": "procurementAdmin",
-  	"password": "$2a$10$1rllCFIqdWhaGQM4sEnQEuUa0XSTyRjuzhXo39VEdyUDOVuc93cGC",
-  	"email": "procurementAdmin@foo.fi",
+    "id": 5,
+    "username": "procurementAdmin",
+    "password": "$2a$10$1rllCFIqdWhaGQM4sEnQEuUa0XSTyRjuzhXo39VEdyUDOVuc93cGC",
+    "email": "procurementAdmin@foo.fi",
     "name": "Aatu Admin",
     "phone": "040 1234567",
     "enlistment": "Admin",

--- a/common/models/costcenter.json
+++ b/common/models/costcenter.json
@@ -65,56 +65,43 @@
       "_selectable": false,
       "comments": "kustannuspaikan nimi"
     },
-    "master": {
+    "controllerUserId": {
       "type": "Number",
+      "id": true,
+      "generated": true,
       "required": false,
       "length": null,
       "precision": 32,
       "scale": 0,
       "postgresql": {
-        "columnName": "master",
+        "columnName": "controllerUserId",
         "dataType": "integer",
         "dataLength": null,
         "dataPrecision": 32,
         "dataScale": 0,
         "nullable": "YES"
       },
-      "_selectable": true,
-      "comments": "päällikkö"
+      "_selectable": false,
+      "comments": "Tämän kustannuspaikan controllerin käyttäjä-id"
     },
-    "provider": {
+    "approverUserId": {
       "type": "Number",
+      "id": true,
+      "generated": true,
       "required": false,
       "length": null,
       "precision": 32,
       "scale": 0,
       "postgresql": {
-        "columnName": "provider",
+        "columnName": "approverUserId",
         "dataType": "integer",
         "dataLength": null,
         "dataPrecision": 32,
         "dataScale": 0,
         "nullable": "YES"
       },
-      "_selectable": true,
-      "comments": "hankkija"
-    },
-    "controller": {
-      "type": "Number",
-      "required": false,
-      "length": null,
-      "precision": 32,
-      "scale": 0,
-      "postgresql": {
-        "columnName": "controller",
-        "dataType": "integer",
-        "dataLength": null,
-        "dataPrecision": 32,
-        "dataScale": 0,
-        "nullable": "YES"
-      },
-      "_selectable": true,
-      "comments": "controller"
+      "_selectable": false,
+      "comments": "Tämän kustannuspaikan hyväksyjän käyttäjä-id"
     }
   },
   "validations": [],
@@ -124,20 +111,15 @@
       "model": "Purchaseorder",
       "foreignKey": "costcenterId"
     },
-    "master": {
+    "approver": {
       "type": "belongsTo",
       "model": "Purchaseuser",
-      "foreignKey": "master"
+      "foreignKey": "approverUserId"
     },
     "controller": {
       "type": "belongsTo",
       "model": "Purchaseuser",
-      "foreignKey": "controller"
-    },
-    "provider": {
-      "type": "belongsTo",
-      "model": "Purchaseuser",
-      "foreignKey": "provider"
+      "foreignKey": "controllerUserId"
     }
   },
   "acls": [

--- a/common/models/purchaseuser.json
+++ b/common/models/purchaseuser.json
@@ -123,93 +123,92 @@
       "model": "Purchaseorder",
       "foreignKey": "subscriberId"
     },
-    "costcenter_master": {
-      "type": "hasMany",
-      "model": "Costcenter",
-      "foreignKey": "master"
+    "costcenters": {
+      "type": "hasAndBelongsToMany",
+      "model": "Costcenter"
     },
-    "costcenter_controller": {
+    "isControllerOfCostcenter": {
       "type": "hasMany",
       "model": "Costcenter",
-      "foreignKey": "controller"
+      "foreignKey": "controllerUserId"
     },
-    "costcenter_provider": {
+    "isApproverOfCostcenter": {
       "type": "hasMany",
       "model": "Costcenter",
-      "foreignKey": "provider"
+      "foreignKey": "approverUserId"
     }
   },
-  "acls": [ 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "$everyone", 
-      "permission": "DENY" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "create" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "deleteById" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "$everyone", 
-      "permission": "ALLOW", 
-      "property": "login" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "exists" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "$everyone", 
-      "permission": "ALLOW", 
-      "property": "logout" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "find" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "findById" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "$owner", 
-      "permission": "ALLOW", 
-      "property": "updateAttributes" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "$everyone", 
-      "permission": "ALLOW", 
-      "property": "confirm" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "upsert" 
-    }, 
-    { 
-      "principalType": "ROLE", 
-      "principalId": "admin", 
-      "permission": "ALLOW", 
-      "property": "updateAll" 
+  "acls": [
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "create"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "deleteById"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "login"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "exists"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "logout"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "find"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "findById"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$owner",
+      "permission": "ALLOW",
+      "property": "updateAttributes"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "ALLOW",
+      "property": "confirm"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "upsert"
+    },
+    {
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW",
+      "property": "updateAll"
     },
     {
       "principalType": "ROLE",

--- a/server/migrate/create-schema.js
+++ b/server/migrate/create-schema.js
@@ -15,7 +15,8 @@ var modelsToAutoMigrate = [
   'Delivery',
   'Costcenter',
   'Purchaseorder',
-  'Purchaseorderrow'
+  'Purchaseorderrow',
+  'PurchaseuserCostcenter'
 ];
 
 db.automigrate(modelsToAutoMigrate, function(err) {


### PR DESCRIPTION
Lisää varsinaisen many-to-many-yhteyden käyttäjien ja laskentakohteiden välille.

Vanhat yhteydet olivat one-to-many, joten niitä ei ainakaan tilaajille voinut käyttää. Niiden tarkoitusta ei ollut dokumetoitu kovin hyvin joten poistin ne tässä samalla. Nimien puolesta tosin ne vaikuttavat sellaisilta että niille on jokin merkitys suunniteltu joten voipi olla että ne pitää palauttaa piakkoin...
