### PR TITLE
Fix tables & fixture creation

### DIFF
--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -2,5 +2,5 @@
 
 cd "$(dirname "$0")"
 
-node ../server/migrate/create-schema.js # drops tables before creating
-node ../server/migrate/create-test-fixtures.js
+SKIP_DATABASE_UPDATE="true" node ../server/migrate/create-schema.js # drops tables before creating
+SKIP_DATABASE_UPDATE="true" node ../server/migrate/create-test-fixtures.js

--- a/server/boot/01-update-database.js
+++ b/server/boot/01-update-database.js
@@ -2,7 +2,8 @@ var Promise = require('bluebird');
 
 module.exports = function updateDatabase(server, cb) {
   var isTest = process.env.NODE_ENV === 'test';
-  if (isTest) {
+  var skipDatabaseUpdate = process.env.SKIP_DATABASE_UPDATE;
+  if (isTest || skipDatabaseUpdate) {
     return cb();
   };
 


### PR DESCRIPTION
Korjaa reset-db.sh-skriptin toiminnan joka oli mennyt autoupdate-bootskriptin vuoksi rikki
