### PR TITLE
Attempt to fix a slug compilation error on Heroku.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "node-sass": "^3.1.0",
     "passport-saml": "^0.12.0",
     "react": "0.13.3",
+    "react-bootstrap": "^0.24.2",
     "react-router": "^0.13.3",
     "react-router-bootstrap": "^0.18.0",
     "sass-loader": "^1.0.3",
@@ -66,7 +67,6 @@
     "file-loader": "^0.8.4",
     "http-proxy": "^1.10.1",
     "mocha": "2.0.1",
-    "react-bootstrap": "^0.24.2",
     "supertest": "^1.0.1",
     "webdriverio": "^3.2.1",
     "webpack-dev-server": "^1.8.0"


### PR DESCRIPTION
Error:
remote: 114333 error code EPEERINVALID
remote: 114334 error peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!
remote: 114334 error peerinvalid Peer react-router@0.13.4 wants react@0.13.x
remote: 114334 error peerinvalid Peer react-bootstrap@0.27.3 wants react@>=0.14.0
