### PR TITLE
Fix bug which caused all objects loaded from backend to be null after LoopBack update

### DIFF
--- a/client/utils/rest.js
+++ b/client/utils/rest.js
@@ -26,31 +26,31 @@ function createRestfulResourceClass(request) {
     }
 
     findAll(cb, filters) {
-      request.get(this.path('', filters)).end(this._handleResponse(cb));
+      request.get(this.path('', filters)).accept('application/json').end(this._handleResponse(cb));
     }
 
     findById(id, cb) {
-      request.get(this.path(id)).end(this._handleResponse(cb));
+      request.get(this.path(id)).accept('application/json').end(this._handleResponse(cb));
     }
 
     create(obj, cb) {
-      request.post(this.path('')).send(obj).end(this._handleResponse(cb));
+      request.post(this.path('')).accept('application/json').send(obj).end(this._handleResponse(cb));
     }
 
     update(id, obj, cb) {
-      request.put(this.path(id)).send(obj).end(this._handleResponse(cb));
+      request.put(this.path(id)).accept('application/json').send(obj).end(this._handleResponse(cb));
     }
 
     del(id, cb) {
-      request.del(this.path(id)).end(this._handleResponse(cb));
+      request.del(this.path(id)).accept('application/json').end(this._handleResponse(cb));
     }
 
     raw(method, path, cb) {
-      request(method, this.path(path)).end(this._handleResponse(cb));
+      request(method, this.path(path)).accept('application/json').end(this._handleResponse(cb));
     }
 
     rawWithBody(method, path, body, cb) {
-      request(method, this.path(path)).send(body).end(this._handleResponse(cb));
+      request(method, this.path(path)).accept('application/json').send(body).end(this._handleResponse(cb));
     }
   }
 


### PR DESCRIPTION
LoopBack update changed default response content type from "application/json" to "application/vnd.api+json". SuperAgent (aka request()) did not recognise this and started handling responses as text, causing request.body to be null. Fixed the problem by changing the Accept header from "_/_" to "application/json".
