### PR TITLE
Add Procfile using npm start as command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start


### PR DESCRIPTION
A custom buildpack is used on heroku, which doesn't allow for omitting
Procfile, so this was needed all along.
