### PR TITLE
Temporarily increase session length to buy some time for fixing sessi…

### DIFF
--- a/server/boot/partioid-login.js
+++ b/server/boot/partioid-login.js
@@ -45,7 +45,7 @@ module.exports = function(app) {
           } else if (user === null) {
             res.send('Sinulla ei vaikuta olevan käyttöoikeuksia tähän järjestelmään. Olethan muistanut tilata oikeudet?');
           } else {
-            user.createAccessToken(3600, function(err, accessToken) {
+            user.createAccessToken(10*3600, function(err, accessToken) {
               if (err) {
                 processError(req, res, err);
               } else {


### PR DESCRIPTION
…on-end issues

The system does not notify users that their session has expired, causing them to enter rows that will not get saved. Due to an unrelated bug, the system does not report errors encountered during save or update of purchase order rows.
