### PR TITLE
Lock Alt minor version to prevent breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "npm": "~2.14.7"
   },
   "dependencies": {
-    "alt": "^0.17.8",
+    "alt": "~0.17.8",
     "babel-core": "^6.1.0",
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.0",


### PR DESCRIPTION
Alt did not follow semver with version 0.18, and it included breaking changes. Lock minor version to 17 to prevent Heroku from using the newer version.
