### PR TITLE
Fix procurement masters row editing bug

### DIFF
--- a/common/models/purchaseorder.js
+++ b/common/models/purchaseorder.js
@@ -132,7 +132,7 @@ module.exports = function(Purchaseorder) {
     var getRoles = Promise.promisify(app.models.Purchaseuser.getRoles, app.models.Purchaseuser);
 
     return getRoles(userId).then(function(roles) {
-      if (_.includes(roles, 'orderer')) {
+      if (_.includes(roles, 'orderer') && !_.includes(roles, 'procurementAdmin') && !_.includes(roles, 'procurementMaster')) {
         return Purchaseorder.checkIfUserHasCostcenter('costcenters', order.costcenterId, userId);
       } else {
         return true;

--- a/server/test/procurement-masters-access.test.js
+++ b/server/test/procurement-masters-access.test.js
@@ -1,0 +1,45 @@
+var app = require('../server');
+var request = require('supertest-as-promised');
+var testUtils = require('./utils/test-utils');
+var Promise = require('bluebird');
+
+describe('Procurement master', function() {
+  var userId;
+  var rowId;
+  var token;
+
+  beforeEach(function() {
+    return testUtils.createUserWithRoles(['orderer', 'procurementMaster']).then(function(user) {
+      userId = user.id;
+      return testUtils.loginUser(user.username);
+    }).then(function(newToken) {
+      token = newToken.id;
+    }).then(function() {
+      return testUtils.createFixture('Purchaseorderrow', {
+        'titleId': 1,
+        'amount': 2,
+        'deliveryId': 1,
+        'orderId': 2,
+        'selfSupply': false,
+        'modified': new Date().toISOString(),
+        'approved': false,
+      });
+    }).then(function(row) {
+      rowId = row.orderRowId;
+    });
+  });
+
+  afterEach(function() {
+    return Promise.join(
+      testUtils.deleteFixtureIfExists('Purchaseuser', userId),
+      testUtils.deleteFixtureIfExists('Purchaseorderrow', rowId)
+    );
+  });
+
+  it('should be allowed to update a row, even if the user is an orderer too', function() {
+    return request(app)
+      .put('/api/Purchaseorders/2/order_rows/' + rowId + '?access_token=' + token)
+      .send({ memo: 'test' })
+      .expect(200);
+  });
+});


### PR DESCRIPTION
There is currently a bug in Hanki that makes it impossible for procurementMaster and procurementAdmin users to edit order rows if they also have the orderer roles. This PR adds a test case for the bug, fixes the bug and also refactors the access control logic so that the bug could be fixed in one place.
